### PR TITLE
np.int -> np.int64 as np.int is deprecated

### DIFF
--- a/mtdlearn/mtd/src.py
+++ b/mtdlearn/mtd/src.py
@@ -62,7 +62,7 @@ class _ChainBase(BaseEstimator):
                          sample_weight: Optional[np.ndarray] = None) -> np.ndarray:
 
         if sample_weight is None:
-            sample_weight = np.ones(x.shape[0], dtype=np.int)
+            sample_weight = np.ones(x.shape[0], dtype=np.int64)
 
         n_columns = x.shape[1]
         values_dict = {i: 0 for i in range(self._n_dimensions ** (x.shape[1]))}
@@ -292,7 +292,7 @@ class MTD(_ChainBase):
                  min_gain: float = 0.1,
                  lambdas_init: Optional[np.ndarray] = None,
                  transition_matrices_init: Optional[np.ndarray] = None,
-                 verbose: np.int = 1,
+                 verbose: np.int64 = 1,
                  n_jobs: int = -1) -> None:
 
         super().__init__(order)


### PR DESCRIPTION
np.int has been deprecated since numpy 1.20 [Numpy 1.20 Release Notes: Deprecation](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated). 
Changed the two occurences of np.int to np.int64, which is the default the alias np.int used to point to. 